### PR TITLE
Dependency source discovery method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to sorcy
+
+Thanks for helping improve `sorcy`.
+
+## Core principles
+
+- Keep changes simple and reliable.
+- Prefer official packaging metadata over scraping.
+- Stay forge-neutral: do not assume one hosting provider is always correct.
+- Add tests for every behavior change.
+
+## Adding support for a new forge
+
+Source resolution lives in `src/sorcy/source_resolver.py`.
+
+When adding a forge:
+
+1. Add host matching logic in `_KNOWN_FORGE_HOSTS` or `_KNOWN_FORGE_HOST_TOKENS`.
+2. Add URL parsing rules only if needed.
+3. Add unit tests in `tests/test_cli.py` for:
+   - direct extraction (`extract_source_repo`)
+   - end-to-end resolution (`resolve_source_repo`)
+4. Keep backward compatibility when possible.
+
+## Note about `AGENTS.md`
+
+`AGENTS.md` is for coding-agent environment behavior.  
+Project mission and contributor policy should live in `README.md` and `CONTRIBUTING.md`.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # sorcy
 
-`sorcy` is a small CLI that reads Python dependencies from `pyproject.toml`, looks up their source repository metadata from PyPI, and writes a Markdown report with GitHub repo pointers.
+`sorcy` is a small CLI that reads Python dependencies from `pyproject.toml`, looks up their source repository metadata from PyPI, and writes a Markdown report with forge repository pointers.
 
 ## Why this exists
 
 Coding agents and humans often need quick links to the actual source code of dependencies.  
-Package manager output is useful, but it usually does not directly produce a clean Markdown list of GitHub org/repo targets for downstream tools.
+Package manager output is useful, but it usually does not directly produce a clean Markdown list of repository targets for downstream tools.
 
 ## MVP scope (current)
 
@@ -17,6 +17,7 @@ Package manager output is useful, but it usually does not directly produce a cle
   - Poetry fallback sections (`[tool.poetry.dependencies]` and poetry groups)
 - Resolver: PyPI JSON API metadata (`project_urls`, `home_page`, `project_url`)
 - Output: Markdown table (`sorcy-dependencies.md` by default)
+- Forge support: GitHub, GitLab, Bitbucket, Codeberg, SourceHut (`git.sr.ht`), plus easy extension for new forges
 
 ## Install (local dev)
 
@@ -55,10 +56,10 @@ python3 -m sorcy . --no-groups
 The report is Markdown and includes:
 
 - dependency name
-- GitHub `org/repo` (if found)
+- source repo as `host/path` (if found)
 - clickable source URL
 
-Dependencies with no GitHub metadata are marked as `_not found_`.
+Dependencies with no usable source metadata are marked as `_not found_`.
 
 ## Reliability and security notes
 
@@ -75,9 +76,16 @@ python3 -m unittest discover -s tests -v
 
 ## About uv / linters
 
-- `uv` is great for resolution/lock/install workflows, but it does not currently provide this exact Markdown GitHub source report out of the box.
+- `uv` is great for resolution/lock/install workflows, but it does not currently provide this exact Markdown source repo report out of the box.
 - Linters are focused on code quality/style/static checks, not dependency source repo mapping.
 - `sorcy` is intended to fill that narrow gap cleanly.
+
+## Project values
+
+- Forge-neutral by default. We support multiple forges and avoid hard-coding one vendor as "the only source of truth."
+- Fast support for new forge hosts. Add host rules in `src/sorcy/source_resolver.py` so community migration can be supported quickly.
+- Prefer open packaging metadata (PyPI JSON) as the primary signal.
+- Contribution workflow and policy: see `CONTRIBUTING.md`.
 
 ## Roadmap
 

--- a/src/sorcy/cli.py
+++ b/src/sorcy/cli.py
@@ -1,22 +1,19 @@
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from typing import Any
 
 import tomllib
 
+from .source_resolver import resolve_source_repo
+
 _NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
-_GITHUB_RE = re.compile(r"github\.com[:/]+([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)", re.IGNORECASE)
-_PREFERRED_URL_LABEL_RE = re.compile(r"(source|repository|repo|code|github)", re.IGNORECASE)
-_PYPI_PROJECT_URL_RE = re.compile(r"^https?://pypi\.org/project/[^/]+/?$", re.IGNORECASE)
+
 @dataclass(frozen=True)
 class ReportRow:
     dependency: str
@@ -89,72 +86,6 @@ def collect_dependency_names(
 
     return sorted(names)
 
-def extract_github_repo(candidate_url: str) -> str | None:
-    match = _GITHUB_RE.search(candidate_url.strip())
-    if not match:
-        return None
-    repo = match.group(1).strip().rstrip("/")
-    if repo.endswith(".git"):
-        repo = repo[:-4]
-    return repo if "/" in repo else None
-
-def _project_url_candidates(info: dict[str, Any]) -> list[str]:
-    preferred: list[str] = []
-    fallback: list[str] = []
-    seen: set[str] = set()
-
-    project_urls = info.get("project_urls", {})
-    if isinstance(project_urls, dict):
-        for label, url in project_urls.items():
-            if not isinstance(url, str):
-                continue
-            cleaned = url.strip()
-            if not cleaned or _PYPI_PROJECT_URL_RE.match(cleaned) or cleaned in seen:
-                continue
-            seen.add(cleaned)
-            if isinstance(label, str) and _PREFERRED_URL_LABEL_RE.search(label):
-                preferred.append(cleaned)
-            else:
-                fallback.append(cleaned)
-
-    for key in ("home_page", "project_url"):
-        value = info.get(key)
-        if not isinstance(value, str):
-            continue
-        cleaned = value.strip()
-        if not cleaned or _PYPI_PROJECT_URL_RE.match(cleaned) or cleaned in seen:
-            continue
-        seen.add(cleaned)
-        fallback.append(cleaned)
-
-    return [*preferred, *fallback]
-
-def fetch_pypi_json(package_name: str, timeout: int = 8) -> dict[str, Any] | None:
-    request = Request(f"https://pypi.org/pypi/{package_name}/json", headers={"User-Agent": "sorcy/0.1"})
-    try:
-        with urlopen(request, timeout=timeout) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except HTTPError as exc:
-        if exc.code == 404:
-            return None
-        raise
-    except (URLError, TimeoutError, json.JSONDecodeError):
-        return None
-
-def resolve_github_repo(
-    package_name: str, fetcher: Callable[[str], dict[str, Any] | None] = fetch_pypi_json
-) -> tuple[str | None, str | None]:
-    payload = fetcher(package_name)
-    if not payload:
-        return None, None
-
-    info = payload.get("info", {})
-    for candidate in _project_url_candidates(info):
-        repo = extract_github_repo(candidate)
-        if repo:
-            return repo, f"https://github.com/{repo}"
-    return None, None
-
 def render_markdown(pyproject_path: Path, rows: list[ReportRow]) -> str:
     stamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     lines = [
@@ -163,7 +94,7 @@ def render_markdown(pyproject_path: Path, rows: list[ReportRow]) -> str:
         f"- Project file: `{pyproject_path}`",
         f"- Generated: `{stamp}`",
         "",
-        "| Dependency | GitHub repo | Source |",
+        "| Dependency | Source repo | Source |",
         "|---|---|---|",
     ]
     for row in rows:
@@ -183,11 +114,11 @@ def run(project_path: Path, output_path: Path, include_optional: bool, include_g
     dependencies = collect_dependency_names(
         pyproject_data, include_optional=include_optional, include_groups=include_groups
     )
-    rows = [ReportRow(dep, *resolve_github_repo(dep)) for dep in dependencies]
+    rows = [ReportRow(dep, *resolve_source_repo(dep)) for dep in dependencies]
 
     output_path.write_text(render_markdown(pyproject_path, rows), encoding="utf-8")
     resolved = sum(1 for row in rows if row.repository)
-    print(f"Wrote {output_path} ({resolved}/{len(rows)} dependencies resolved to GitHub).")
+    print(f"Wrote {output_path} ({resolved}/{len(rows)} dependencies resolved to source repos).")
     return 0
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/sorcy/source_resolver.py
+++ b/src/sorcy/source_resolver.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+_PREFERRED_URL_LABEL_RE = re.compile(r"(source|repository|repo|code|github)", re.IGNORECASE)
+_PYPI_PROJECT_URL_RE = re.compile(r"^https?://pypi\.org/project/[^/]+/?$", re.IGNORECASE)
+_SCP_STYLE_GIT_URL_RE = re.compile(r"^(?:[^@/]+@)?([A-Za-z0-9.-]+):([^?#]+)$")
+_FORGE_PATH_CUT_MARKERS = (
+    "/-/",
+    "/tree/",
+    "/blob/",
+    "/src/",
+    "/raw/",
+    "/issues/",
+    "/pull/",
+    "/pulls/",
+    "/merge_requests/",
+    "/commit/",
+    "/commits/",
+    "/release/",
+    "/releases/",
+    "/wiki/",
+)
+_KNOWN_FORGE_HOSTS = {
+    "github.com",
+    "gitlab.com",
+    "bitbucket.org",
+    "codeberg.org",
+    "git.sr.ht",
+}
+_KNOWN_FORGE_HOST_TOKENS = ("github", "gitlab", "bitbucket", "codeberg", "sourcehut", "gitea", "forgejo")
+
+
+def _looks_like_forge_host(host: str) -> bool:
+    lowered = host.lower()
+    if lowered in _KNOWN_FORGE_HOSTS:
+        return True
+    return any(token in lowered for token in _KNOWN_FORGE_HOST_TOKENS)
+
+
+def _extract_repo_path(path: str) -> str | None:
+    trimmed = path
+    for marker in _FORGE_PATH_CUT_MARKERS:
+        if marker in trimmed:
+            trimmed = trimmed.split(marker, 1)[0]
+    trimmed = trimmed.strip().strip("/")
+    if trimmed.endswith(".git"):
+        trimmed = trimmed[:-4]
+    parts = [part for part in trimmed.split("/") if part]
+    if len(parts) < 2:
+        return None
+    return "/".join(parts)
+
+
+def extract_source_repo(candidate_url: str, *, allow_unlisted_host: bool = False) -> tuple[str, str] | None:
+    cleaned = candidate_url.strip()
+    if not cleaned:
+        return None
+    if cleaned.startswith("git+"):
+        cleaned = cleaned[4:]
+
+    host = ""
+    path = ""
+    if "://" in cleaned:
+        parsed = urlparse(cleaned)
+        host = (parsed.hostname or "").lower()
+        path = parsed.path
+    else:
+        match = _SCP_STYLE_GIT_URL_RE.match(cleaned)
+        if not match:
+            return None
+        host = match.group(1).lower()
+        path = match.group(2)
+
+    if not host or host == "pypi.org":
+        return None
+    if not allow_unlisted_host and not _looks_like_forge_host(host):
+        return None
+
+    repo_path = _extract_repo_path(path)
+    if not repo_path:
+        return None
+
+    repo = f"{host}/{repo_path}"
+    return repo, f"https://{host}/{repo_path}"
+
+
+def extract_github_repo(candidate_url: str) -> str | None:
+    extracted = extract_source_repo(candidate_url, allow_unlisted_host=True)
+    if not extracted:
+        return None
+    repo, _ = extracted
+    if not repo.startswith("github.com/"):
+        return None
+    return repo.split("/", 1)[1]
+
+
+def _project_url_candidates(info: dict[str, Any]) -> list[tuple[str, bool]]:
+    preferred: list[tuple[str, bool]] = []
+    fallback: list[tuple[str, bool]] = []
+    seen: set[str] = set()
+
+    project_urls = info.get("project_urls", {})
+    if isinstance(project_urls, dict):
+        for label, url in project_urls.items():
+            if not isinstance(url, str):
+                continue
+            cleaned = url.strip()
+            if not cleaned or _PYPI_PROJECT_URL_RE.match(cleaned) or cleaned in seen:
+                continue
+            seen.add(cleaned)
+            if isinstance(label, str) and _PREFERRED_URL_LABEL_RE.search(label):
+                preferred.append((cleaned, True))
+            else:
+                fallback.append((cleaned, False))
+
+    for key in ("home_page", "project_url"):
+        value = info.get(key)
+        if not isinstance(value, str):
+            continue
+        cleaned = value.strip()
+        if not cleaned or _PYPI_PROJECT_URL_RE.match(cleaned) or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        fallback.append((cleaned, False))
+
+    return [*preferred, *fallback]
+
+
+def fetch_pypi_json(package_name: str, timeout: int = 8) -> dict[str, Any] | None:
+    request = Request(f"https://pypi.org/pypi/{package_name}/json", headers={"User-Agent": "sorcy/0.1"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+    except (URLError, TimeoutError, json.JSONDecodeError):
+        return None
+
+
+def resolve_source_repo(
+    package_name: str, fetcher: Callable[[str], dict[str, Any] | None] = fetch_pypi_json
+) -> tuple[str | None, str | None]:
+    payload = fetcher(package_name)
+    if not payload:
+        return None, None
+
+    info = payload.get("info", {})
+    for candidate, preferred_label in _project_url_candidates(info):
+        extracted = extract_source_repo(candidate, allow_unlisted_host=preferred_label)
+        if extracted:
+            return extracted
+    return None, None
+
+
+def resolve_github_repo(
+    package_name: str, fetcher: Callable[[str], dict[str, Any] | None] = fetch_pypi_json
+) -> tuple[str | None, str | None]:
+    return resolve_source_repo(package_name, fetcher=fetcher)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from sorcy import cli
+from sorcy import source_resolver
 
 
 class SorcyCliTests(unittest.TestCase):
@@ -30,39 +31,66 @@ class SorcyCliTests(unittest.TestCase):
 
     def test_extract_github_repo(self) -> None:
         self.assertEqual(
-            cli.extract_github_repo("git+https://github.com/pallets/flask.git"),
+            source_resolver.extract_github_repo("git+https://github.com/pallets/flask.git"),
             "pallets/flask",
         )
         self.assertEqual(
-            cli.extract_github_repo("git@github.com:psf/requests.git"),
+            source_resolver.extract_github_repo("git@github.com:psf/requests.git"),
             "psf/requests",
         )
-        self.assertIsNone(cli.extract_github_repo("https://example.com/nope"))
+        self.assertIsNone(source_resolver.extract_github_repo("https://example.com/nope"))
 
-    def test_resolve_github_repo(self) -> None:
+    def test_extract_source_repo_multiple_forges(self) -> None:
+        self.assertEqual(
+            source_resolver.extract_source_repo("git+https://github.com/pallets/flask.git"),
+            ("github.com/pallets/flask", "https://github.com/pallets/flask"),
+        )
+        self.assertEqual(
+            source_resolver.extract_source_repo("https://gitlab.com/pallets/flask/-/tree/main"),
+            ("gitlab.com/pallets/flask", "https://gitlab.com/pallets/flask"),
+        )
+        self.assertEqual(
+            source_resolver.extract_source_repo("ssh://git@bitbucket.org/team/repo.git"),
+            ("bitbucket.org/team/repo", "https://bitbucket.org/team/repo"),
+        )
+        self.assertEqual(
+            source_resolver.extract_source_repo("https://codeberg.org/org/project/src/branch/main"),
+            ("codeberg.org/org/project", "https://codeberg.org/org/project"),
+        )
+
+    def test_extract_source_repo_unknown_host_behavior(self) -> None:
+        self.assertIsNone(source_resolver.extract_source_repo("https://example.com/team/repo"))
+        self.assertEqual(
+            source_resolver.extract_source_repo(
+                "https://git.example.org/group/project.git", allow_unlisted_host=True
+            ),
+            ("git.example.org/group/project", "https://git.example.org/group/project"),
+        )
+
+    def test_resolve_source_repo(self) -> None:
         def fake_fetcher(_: str) -> dict:
-            return {"info": {"project_urls": {"Source": "https://github.com/psf/requests"}}}
+            return {"info": {"project_urls": {"Source": "https://gitlab.com/psf/requests"}}}
 
-        repo, url = cli.resolve_github_repo("requests", fetcher=fake_fetcher)
-        self.assertEqual(repo, "psf/requests")
-        self.assertEqual(url, "https://github.com/psf/requests")
+        repo, url = source_resolver.resolve_source_repo("requests", fetcher=fake_fetcher)
+        self.assertEqual(repo, "gitlab.com/psf/requests")
+        self.assertEqual(url, "https://gitlab.com/psf/requests")
 
-    def test_resolve_github_repo_prefers_repository_labels(self) -> None:
+    def test_resolve_source_repo_prefers_repository_labels(self) -> None:
         def fake_fetcher(_: str) -> dict:
             return {
                 "info": {
                     "project_urls": {
                         "Documentation": "https://requests.readthedocs.io",
-                        "Repository": "https://github.com/psf/requests",
+                        "Repository": "https://codeberg.org/org/requests",
                     }
                 }
             }
 
-        repo, url = cli.resolve_github_repo("requests", fetcher=fake_fetcher)
-        self.assertEqual(repo, "psf/requests")
-        self.assertEqual(url, "https://github.com/psf/requests")
+        repo, url = source_resolver.resolve_source_repo("requests", fetcher=fake_fetcher)
+        self.assertEqual(repo, "codeberg.org/org/requests")
+        self.assertEqual(url, "https://codeberg.org/org/requests")
 
-    def test_resolve_github_repo_skips_pypi_project_url(self) -> None:
+    def test_resolve_source_repo_skips_pypi_project_url(self) -> None:
         def fake_fetcher(_: str) -> dict:
             return {
                 "info": {
@@ -72,7 +100,7 @@ class SorcyCliTests(unittest.TestCase):
                 }
             }
 
-        repo, url = cli.resolve_github_repo("requests", fetcher=fake_fetcher)
+        repo, url = source_resolver.resolve_source_repo("requests", fetcher=fake_fetcher)
         self.assertIsNone(repo)
         self.assertIsNone(url)
 
@@ -94,15 +122,15 @@ class SorcyCliTests(unittest.TestCase):
             output = project / "deps.md"
 
             with mock.patch(
-                "sorcy.cli.resolve_github_repo",
-                return_value=("psf/requests", "https://github.com/psf/requests"),
+                "sorcy.cli.resolve_source_repo",
+                return_value=("gitlab.com/psf/requests", "https://gitlab.com/psf/requests"),
             ):
                 rc = cli.run(project, output, include_optional=True, include_groups=True)
 
             self.assertEqual(rc, 0)
             content = output.read_text(encoding="utf-8")
             self.assertIn("`requests`", content)
-            self.assertIn("`psf/requests`", content)
+            self.assertIn("`gitlab.com/psf/requests`", content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Harden PyPI dependency source resolver by prioritizing specific `project_urls` labels and skipping PyPI self-links.

---
<p><a href="https://cursor.com/agents/bc-b67bab38-4ba4-4cc3-a983-8cb2eca7d9fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b67bab38-4ba4-4cc3-a983-8cb2eca7d9fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->