### PR TITLE
docs: split user README commands from contributor mise workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,18 +51,25 @@ When adding a forge:
 
 ## Running tests
 
+Bootstrap local tools once:
+
 ```bash
-./bin/mise run test
+./bin/mise install
+```
+
+After bootstrap, use `mise` directly for routine commands:
+
+```bash
+mise run test
 ```
 
 ### Optional live registry + materialization smoke tests
 
 These tests are intentionally opt-in and are meant for bigger feature milestones.
 They hit real registries (PyPI, npm, crates.io), resolve real dependencies, and clone real repos.
-Run them inside a mise-bootstrapped environment (run `./bin/mise install` first).
 
 ```bash
-./bin/mise x -- bash -lc 'SORCY_LIVE_TESTS=1 cargo test -p sorcy-core --test live_registry_optional -- --ignored --nocapture'
+mise x -- bash -lc 'SORCY_LIVE_TESTS=1 cargo test -p sorcy-core --test live_registry_optional -- --ignored --nocapture'
 ```
 
 Notes:
@@ -73,3 +80,69 @@ Notes:
 
 `AGENTS.md` is for coding-agent environment behavior.  
 Project mission and contributor policy should live in `README.md` and `CONTRIBUTING.md`.
+
+## Contributor command reference (mise wrappers)
+
+Bootstrap local tools once:
+
+```bash
+./bin/mise install
+```
+
+After bootstrap, use `mise` directly for day-to-day contributor workflows:
+
+Build all workspace members:
+
+```bash
+mise run build
+```
+
+Run CLI against current directory:
+
+```bash
+mise x -- cargo run -p sorcy -- .
+```
+
+Pretty JSON:
+
+```bash
+mise x -- cargo run -p sorcy -- . --pretty
+```
+
+Write to file:
+
+```bash
+mise x -- cargo run -p sorcy -- . --output sorcy-sources.json --pretty
+```
+
+Materialize resolved repositories into the hidden local cache while keeping default JSON output:
+
+```bash
+mise x -- cargo run -p sorcy -- . --materialize
+```
+
+Materialize and print rich JSON (scan + cache + per-resolution clone state):
+
+```bash
+mise x -- cargo run -p sorcy -- . --materialize --materialize-rich --pretty
+```
+
+Run tests:
+
+```bash
+mise run test
+```
+
+Optional live smoke tests (opt-in, network + real repo clones):
+
+```bash
+mise x -- bash -lc 'SORCY_LIVE_TESTS=1 cargo test -p sorcy-core --test live_registry_optional -- --ignored --nocapture'
+```
+
+Local update flow (includes `self-update`) remains available:
+
+```bash
+mise run update
+```
+
+`mise run ci` remains build + test only and does not run `update` or `self-update`.

--- a/README.md
+++ b/README.md
@@ -95,61 +95,47 @@ URL normalization and retry behavior are preserved.
 
 ## Build, run, test
 
-Bootstrap local tools first:
-
-```bash
-./bin/mise install
-```
-
 Build all workspace members:
 
 ```bash
-./bin/mise run build
+cargo build --workspace
 ```
 
 Run CLI against current directory:
 
 ```bash
-./bin/mise x -- cargo run -p sorcy -- .
+cargo run -- .
 ```
 
 Pretty JSON:
 
 ```bash
-./bin/mise x -- cargo run -p sorcy -- . --pretty
+cargo run -- . --pretty
 ```
 
 Write to file:
 
 ```bash
-./bin/mise x -- cargo run -p sorcy -- . --output sorcy-sources.json --pretty
+cargo run -- . --output sorcy-sources.json --pretty
 ```
 
 Materialize resolved repositories into the hidden local cache while keeping default JSON output:
 
 ```bash
-./bin/mise x -- cargo run -p sorcy -- . --materialize
+cargo run -- . --materialize
 ```
 
 Materialize and print rich JSON (scan + cache + per-resolution clone state):
 
 ```bash
-./bin/mise x -- cargo run -p sorcy -- . --materialize --materialize-rich --pretty
+cargo run -- . --materialize --materialize-rich --pretty
 ```
 
 Run tests:
 
 ```bash
-./bin/mise run test
+cargo test --workspace
 ```
-
-Optional live smoke tests (opt-in, network + real repo clones):
-
-```bash
-./bin/mise x -- bash -lc 'SORCY_LIVE_TESTS=1 cargo test -p sorcy-core --test live_registry_optional -- --ignored --nocapture'
-```
-
-Use this after larger feature work when you want extra confidence against real registries.
 
 ## Settings precedence
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reverted README `Build, run, test` examples to plain `cargo` commands
- removed live smoke test command examples from README
- added a contributor-focused command reference at the bottom of `CONTRIBUTING.md`
- clarified contributor bootstrap flow: run `./bin/mise install` once, then use `mise ...` commands for routine work
- documented that `mise run update` remains local (includes `self-update`) while CI remains build+test only

## Testing
- verified README command section now only contains cargo commands and no `./bin/mise` or live-test examples
- verified contributor command reference at bottom of `CONTRIBUTING.md` includes bootstrap + routine `mise` usage and update/CI notes
- ran tests with managed toolchain: `/home/ubuntu/.local/bin/mise run test` (pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [BE-24](https://linear.app/busyearth/issue/BE-24/docs-cleanup-split-user-vs-contributor-commands-readme-contributing)

<div><a href="https://cursor.com/agents/bc-0b997571-637a-496b-86e6-e9a837447392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b997571-637a-496b-86e6-e9a837447392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

