### PR TITLE
docs: add Cloud Agent setup gotchas to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,12 @@ This is a Rust project (`sorcy`) that provides a small CLI for dependency source
 - To update all versions (toolchain + crates): `./bin/mise run update`
 - The project uses `Cargo.toml` as the dependency manifest.
 
+### Gotchas
+
+- On first use, mise requires trusting the config: `~/.local/bin/mise trust /workspace/mise.toml`
+- After `./bin/mise install`, activate mise in the current shell so `cargo`/`rustc` are on PATH: `eval "$(/home/ubuntu/.local/bin/mise activate bash)"`
+- No external services (databases, Docker, etc.) are required. All default tests use an in-process mock HTTP server.
+
 ### Running / Testing
 
 - Build: `cargo build`

--- a/mise.lock
+++ b/mise.lock
@@ -5,5 +5,5 @@ version = "0.13.9"
 backend = "cargo:cargo-edit"
 
 [[tools.rust]]
-version = "1.94.0"
+version = "1.94.1"
 backend = "core:rust"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds practical setup notes to `AGENTS.md` discovered during Cloud Agent environment bootstrapping, and bumps the Rust lockfile to the latest patch release.

### Changes

- **`AGENTS.md`**: Added gotchas section — `mise trust` requirement, shell activation step, clarification that no external services are needed
- **`mise.lock`**: Rust 1.94.0 → 1.94.1 (routine patch bump from `rust = "latest"`)

## Verification

All checks pass on this environment:

- `cargo build --workspace` — compiles cleanly (rustc 1.94.1)
- `cargo test --workspace` — 28 tests pass, 2 live tests intentionally ignored
- `cargo run -- . --pretty` — CLI resolves 9 dependency source URLs from the workspace's own manifests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00c18e2f-7f6c-4631-bd8a-c72078642591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00c18e2f-7f6c-4631-bd8a-c72078642591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

